### PR TITLE
[ci] move the doc and docker part on master

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -9,11 +9,11 @@ on:
   #schedule:
   #  - cron: '40 18 * * *'
   push:
-    branches: [ "develop" ]
+    branches: [ "master" ]
     # Publish semver tags as releases.
     tags: [ '*.*.*' ]
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "master", "develop" ]
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["develop"]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,7 +56,7 @@ jobs:
           path: 'documentation/_build/html'
 
   deploy:
-    # if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,7 +56,7 @@ jobs:
           path: 'documentation/_build/html'
 
   deploy:
-    if: github.event_name != 'pull_request'
+    # if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,10 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
+    # Publish semver tags as releases.
+    tags: [ '*.*.*' ]
+  pull_request:
+    branches: [ "master", "develop" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -51,12 +55,15 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v2
+        if: github.event_name != 'pull_request'
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
+        if: github.event_name != 'pull_request'
         with:
           path: 'documentation/_build/html'
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
+        if: github.event_name != 'pull_request'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,14 +28,9 @@ env:
   PYTHON_VERSION: "3.10"
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -47,23 +42,27 @@ jobs:
           cache-dependency-path: "requirements/*.txt"
 
       - name: Install documentation requirements
-        run: |
-          python -m pip install -U -r requirements/documentation.txt
+        run: python -m pip install -U -r requirements/documentation.txt
+      
       - name: Build doc using Sphinx
         run: sphinx-build -b html -j auto -d documentation/_build/cache -q documentation documentation/_build/html
 
-
       - name: Setup Pages
         uses: actions/configure-pages@v2
-        if: github.event_name != 'pull_request'
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
-        if: github.event_name != 'pull_request'
         with:
           path: 'documentation/_build/html'
 
+  deploy:
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
-        if: github.event_name != 'pull_request'

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Une image docker est disponible dans le dossier [docker](./docker). Cette image 
 
 ## Version
 
-Version des procèdures: 2.1.1-DEVELOP
+Version des procèdures: 2.1.0
 
 ## Licence
 

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Une image docker est disponible dans le dossier [docker](./docker). Cette image 
 
 ## Version
 
-Version des procèdures: 2.1.0
+Version des procèdures: 2.1.1-DEVELOP
 
 ## Licence
 


### PR DESCRIPTION
We will return to a previous way of working : releases are made from master and not develop. That's why I've updated the CI. 