### PR TITLE
[fix] delete doc deployment on tags

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,8 +5,6 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
-    # Publish semver tags as releases.
-    tags: [ '*.*.*' ]
   pull_request:
     branches: [ "master", "develop" ]
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.1.2
+
+FIXED:
+- correction pour éviter de publier github pages sur un tag
+
 ## 2.1.1
 
 CHANGED:

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Une image docker est disponible dans le dossier [docker](./docker). Cette image 
 
 ## Version
 
-Version des procèdures: 2.1.1
+Version des procèdures: 2.1.2
 
 ## Licence
 


### PR DESCRIPTION
We want to publish the doc related to the last master commit and not to a tag. 